### PR TITLE
add rp2350 compatibility and add options for multiple instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Additionally here is a project that use this driver in the wild:
 
 ## Requirements
 This program assumes:
-* 125MHz pio clock source
+* 200MHz (maximum) pio clock source
 
 This program consumes:
 * 1 PIO state machine

--- a/inc/pio_ltc264x.h
+++ b/inc/pio_ltc264x.h
@@ -73,6 +73,12 @@ public:
     void write_value(uint16_t value);
 
 /**
+ * \brief get the most-recently-written value written with write_value().
+ */
+    inline uint16_t get_last_value()
+    {return last_value_;}
+
+/**
  * \brief Configure single-shot or continuous streaming of a specified number
     of values to a specified memory location at the specified interval.
 */
@@ -137,6 +143,7 @@ private:
     uint sm_;
     PIO pio_;
     int32_t offset_; // pio program offset.
+    uint16_t last_value_;
     uint16_t* data_ptr_[1];   // Data that the reconfiguration channel will write back
                             // to the sample channel. In this case, just the
                             // address of the location of the adc samples. This

--- a/inc/pio_ltc264x.h
+++ b/inc/pio_ltc264x.h
@@ -22,6 +22,7 @@
 class PIO_LTC264x
 {
 public:
+
 /**
  * \brief constructor. Setup gpio pins, state machine.
  * \note CS pin is \p sck_pin + 1.
@@ -53,6 +54,12 @@ public:
  */
     int32_t get_sm() const
     {return sm_;}
+
+/**
+ * \brief
+ */
+    PIO& get_pio() const
+    {return pio_;}
 
 /**
  * \brief Write a single value to output to the DAC.

--- a/inc/pio_ltc264x.h
+++ b/inc/pio_ltc264x.h
@@ -33,7 +33,7 @@ public:
  *  If specified as < 0 (default), add the program at the next available offset when
  *  `add_program == 1`. (Invalid to leave as < 0 (unspecified) when \p add_program is true.)
  */
-    PIO_LTC264x(PIO pio, uint8_t sck_pin, uint8_t pico_pin,
+    PIO_LTC264x(PIO pio, size_t sck_pin, size_t pico_pin,
                 bool add_program = true, int32_t program_offset = -1);
 
     ~PIO_LTC264x();
@@ -58,7 +58,7 @@ public:
 /**
  * \brief
  */
-    PIO& get_pio() const
+    PIO& get_pio()
     {return pio_;}
 
 /**

--- a/inc/pio_ltc264x.h
+++ b/inc/pio_ltc264x.h
@@ -45,13 +45,13 @@ public:
 /**
  * \brief
  */
-    int32_t get_offset()
+    int32_t get_offset() const
     {return offset_;}
 
 /**
  * \brief
  */
-    int32_t get_sm()
+    int32_t get_sm() const
     {return sm_;}
 
 /**

--- a/inc/pio_ltc264x.h
+++ b/inc/pio_ltc264x.h
@@ -25,10 +25,34 @@ public:
 /**
  * \brief constructor. Setup gpio pins, state machine.
  * \note CS pin is \p sck_pin + 1.
+ * \param add_program if true (default) upload the pio program to the specified
+ *  PIO bank.
+ * \param program_offset if specified >= 0, either add the program at this
+ *  offset (`add_program = 1`) or use the program at this offset (`add_program = 0`).
+ *  If specified as < 0 (default), add the program at the next available offset when
+ *  `add_program == 1`. (Invalid to leave as < 0 (unspecified) when \p add_program is true.)
  */
-    PIO_LTC264x(PIO pio, uint8_t sck_pin, uint8_t pico_pin);
+    PIO_LTC264x(PIO pio, uint8_t sck_pin, uint8_t pico_pin,
+                bool add_program = true, int32_t program_offset = -1);
 
     ~PIO_LTC264x();
+
+/**
+ * \brief launch the pio program
+ */
+    void start() const;
+
+/**
+ * \brief
+ */
+    int32_t get_offset()
+    {return offset_;}
+
+/**
+ * \brief
+ */
+    int32_t get_sm()
+    {return sm_;}
 
 /**
  * \brief Write a single value to output to the DAC.
@@ -99,17 +123,13 @@ public:
                                        irq_handler_t handler_func);
 */
 
-/**
- * \brief launch the pio program
- */
-    void start();
-
     int samp_chan_; // DMA channel used to collect samples and fire an interrupt
                     // if configured to do so. If it fires an interrupt,
                     // a DMA handler function needs to clear it.
 private:
-    PIO pio_;
     uint sm_;
+    PIO pio_;
+    int32_t offset_; // pio program offset.
     uint16_t* data_ptr_[1];   // Data that the reconfiguration channel will write back
                             // to the sample channel. In this case, just the
                             // address of the location of the adc samples. This

--- a/src/pio_ltc264x.cpp
+++ b/src/pio_ltc264x.cpp
@@ -2,20 +2,39 @@
 
 // FIXME: rewrite this for the LTC264x
 
-PIO_LTC264x::PIO_LTC264x(PIO pio, uint8_t sck_pin, uint8_t pico_pin)
-:pio_{pio}
+PIO_LTC264x::PIO_LTC264x(PIO pio, uint8_t sck_pin, uint8_t pico_pin,
+                         bool add_program, int32_t program_offset)
+:pio_{pio}, offset_{program_offset}
 {
+    // 3 Legit Cases:
+    // 1. Add a program at the next available offset.
+    // 2. Add a program at a specified offset.
+    // 3. Use an existing program at a specified offset.
+
     // Note: CS_PIN is fixed as SCK_PIN + 1.
-    uint offset;
-    offset = pio_add_program(pio_, &spi_cpha0_cs_program);
+    if (add_program == true)
+    {
+        // Add program at a specified offset.
+        if (program_offset >= 0)
+            pio_add_program_at_offset(pio_, &spi_cpha0_cs_program, offset_);
+        else
+            offset_ = pio_add_program(pio_, &spi_cpha0_cs_program);
+    }
+    // Else: use an existing program at the specified offset. (Must be >= 0).
     sm_ = pio_claim_unused_sm(pio_, true);
     // Configure pio program. Note: cs_pin is sck_pin + 1.
-    setup_pio_ltc264x(pio_, sm_, offset, sck_pin, pico_pin);
+    setup_pio_ltc264x(pio_, sm_, offset_, sck_pin, pico_pin);
 }
 
 PIO_LTC264x::~PIO_LTC264x()
 {
-    // TODO: state machine cleanup.
+    // FIXME: state machine cleanup.
+}
+
+void PIO_LTC264x::start() const
+{
+    // launch the PIO program.
+    pio_ltc264x_start(pio_, sm_);
 }
 
 void PIO_LTC264x::write_value(uint16_t value)
@@ -131,9 +150,3 @@ void PIO_LTC264x::_setup_dma_stream_from_memory(
     //printf("Configured DMA control channel.\r\n");
 }
 */
-
-void PIO_LTC264x::start()
-{
-    // launch the PIO program.
-    pio_ltc264x_start(pio_, sm_);
-}

--- a/src/pio_ltc264x.cpp
+++ b/src/pio_ltc264x.cpp
@@ -2,7 +2,7 @@
 
 // FIXME: rewrite this for the LTC264x
 
-PIO_LTC264x::PIO_LTC264x(PIO pio, uint8_t sck_pin, uint8_t pico_pin,
+PIO_LTC264x::PIO_LTC264x(PIO pio, size_t sck_pin, size_t pico_pin,
                          bool add_program, int32_t program_offset)
 :pio_{pio}, offset_{program_offset}
 {

--- a/src/pio_ltc264x.cpp
+++ b/src/pio_ltc264x.cpp
@@ -4,7 +4,7 @@
 
 PIO_LTC264x::PIO_LTC264x(PIO pio, size_t sck_pin, size_t pico_pin,
                          bool add_program, int32_t program_offset)
-:pio_{pio}, offset_{program_offset}
+:pio_{pio}, offset_{program_offset}, last_value_{0}
 {
     // 3 Legit Cases:
     // 1. Add a program at the next available offset.
@@ -41,10 +41,11 @@ void PIO_LTC264x::write_value(uint16_t value)
 {
     // Push value into the PIO TX FIFO.
     // Note: data is loaded MSbit first from the TX FIFO (32-bit).
-    pio_sm_put_blocking(pio_, sm_, (value<<16)); // blocks if the TX FIFO is
-                                                 // full, which should not
-                                                 // happen unless we are calling
-                                                 // it too fast.
+    pio_sm_put_blocking(pio_, sm_, uint32_t(value<<16)); // blocks if the TX
+                                                 // FIFO is full, which should
+                                                 // not happen unless we are
+                                                // calling it too fast.
+    last_value_ = value;
 }
 
 /*

--- a/src/pio_ltc264x.pio
+++ b/src/pio_ltc264x.pio
@@ -36,6 +36,8 @@
 ; CPHA=0: data is captured on the leading edge of each SCK pulse (including
 ; the first pulse), and transitions on the trailing edge
 
+.pio_version 0 // only requires PIO version 0
+
 .program spi_cpha0_cs
 .side_set 2
 


### PR DESCRIPTION
* Validate compatibility with the RP2350 at 150MHz
* Make it easier to have multiple class instances but share the same PIO and program
* Expose last value written manually.
* Add getter functions for underlying hardware.